### PR TITLE
fix: update markeplace to implement the right interfaces

### DIFF
--- a/Marketplace.sol
+++ b/Marketplace.sol
@@ -2,8 +2,10 @@
 pragma solidity ^0.8.26;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
-contract Marketplace {
+
+contract Marketplace is IERC721Receiver {
 
     struct Listing {
         address seller;
@@ -45,6 +47,15 @@ contract Marketplace {
     function unpause() public onlyOwner {
         paused = false;
         emit Unpaused();
+    }
+
+    function onERC721Received(
+        address,
+        address,
+        uint256,
+        bytes memory
+    ) public virtual override returns (bytes4) {
+        return this.onERC721Received.selector;
     }
 
     function listNFT(address nftContract, uint256 tokenId, uint256 price) external whenNotPaused {

--- a/MyNFT.sol
+++ b/MyNFT.sol
@@ -17,5 +17,6 @@ contract MyNFT is ERC721 {
     }
 
     function approveMarketplace(address marketplace) public {
-        setApprovalForAll(marketplace,true);}
+        _setApprovalForAll(msg.sender, marketplace,true);
+    }
 }


### PR DESCRIPTION
This PR fixes a couple of problems:

The `_` was missing before `setApprovalForAll`, as it's an internal function inherited from ERC721.
There was an extra semicolon `;` at the end of the line, just before the closing brace `}`.

Also consider implementing `IERC721Receiver` 

More information [here](https://docs.openzeppelin.com/contracts/5.x/api/token/erc721#IERC721Receiver)

This function returns the first 4 bytes of the keccak256 hash of the function's signature to tell the calling contract that this contract is capable of receiving ERC721 tokens.

```
        function onERC721Received(
            address,
            address,
            uint256,
            bytes memory
        ) public virtual override returns (bytes4) {
            return this.onERC721Received.selector;
        }
```

